### PR TITLE
Changes on API authentication to get API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,46 @@
-node-couchpotato
-================
+# node-couchpotato
 
-Small node module used to query the Couchpotato v2 API
+Small node module used to query the
+[CouchPotatoServer](https://couchpota.to) v2 API. For further
+details on supported API calls, please check your CouchPotato
+installation at `http://{url}:{port}/docs`
+
+## Usage Examples
+
+
+### Instantiate with login credentials
+
+``` javascript
+var CouchPotato= require('couchpotato');
+
+var cp= new CouchPotato({url} // IP/url without http
+  , {port}
+  , {username}
+  , {password});
+
+```
+
+### Instantiate without login credentials
+
+``` javascript
+var CouchPotato= require('couchpotato');
+
+var cp= new CouchPotato({url} // IP/url without http
+  , {port});
+```
+
+### Query API
+
+To get the list of movies with status *done* execute like:
+
+``` javascript
+cp.getKey(function(res) {
+  console.log('result', res);
+  cp.query('movie.list', {
+      status: 'done'
+    , limit_offset: 10
+  }, function(res, body) {
+    console.log('result', res, 'body', body);
+  });
+});
+```

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,5 +1,6 @@
 var request = require("request");
 var qs = require('querystring');
+var crypto = require('crypto');
 
 var COUCHPOTATO_NOUSERNAME = "md5(username)";
 var COUCHPOTATO_NOPASSWORD = "md5(password)";
@@ -9,10 +10,22 @@ module.exports = Couchpotato;
 function Couchpotato(hostname, port, username, password) {
     this.hostname = hostname;
     this.port = port;
+
+    // FIXME: what aobut https?
     this.serverUrl = "http://" + hostname + ":" + this.port;
 
-    this.username = username || COUCHPOTATO_NOUSERNAME;
-    this.password = password || COUCHPOTATO_NOPASSWORD;
+    if(!username && !password) {
+        this.username = COUCHPOTATO_NOUSERNAME;
+        this.password = COUCHPOTATO_NOPASSWORD;
+    } else {
+        this.username = crypto.createHash('md5')
+            .update(username)
+            .digest('hex');
+        this.password = crypto.createHash('md5')
+            .update(password)
+            .digest('hex');
+    }
+
     this.key = null;
 }
 
@@ -30,8 +43,13 @@ Couchpotato.prototype.getKey = function(callback) {
     }
 
     var context = this;
+    var url = this.serverUrl + "/getkey/"
+        + "?p=" + this.password
+        + "&u=" + this.username;
+    // console.log(url);
+
     request({
-        "uri": this.serverUrl + "/getkey/?p=" + this.password + "&u=" + this.username,
+        "uri": url,
         "json": true
     }, function(error, response, body) {
         if (!error && response.statusCode == 200) {

--- a/tests/app.available.js
+++ b/tests/app.available.js
@@ -1,10 +1,14 @@
 var Couchpotato = require('../lib/api');
-var couchpotato = new Couchpotato("192.168.1.20", 5050);
+var couchpotato = new Couchpotato("192.168.1.20", 5050, "username", "password");
 couchpotato.getKey(function(success) {
     if (success) {
         couchpotato.query("app.available", function(reqsuccess, result) {
             console.log("RESULT", reqsuccess ? "OK" : "FAILED");
             console.log(result);
+            couchpotato.query("app.version", function(reqsuccess, result) {
+                console.log('RESULT', reqsuccess ? result.version : "FAILED");
+                console.log(result);
+            });
         });
     }
 });


### PR DESCRIPTION
getkey API call requires username and password to be md5'd.  If username and password are empty, they don't need to be md5'd.

``` javascript
var COUCHPOTATO_NOUSERNAME = "md5(username)";
var COUCHPOTATO_NOPASSWORD = "md5(password)";
```

was not correct way to authenticate without username and password.

Added a `api.version` call to tests to verify API calls really working.

Added some more usage documentation to README.
